### PR TITLE
add missing input-group styles

### DIFF
--- a/lib/form-control.scss
+++ b/lib/form-control.scss
@@ -157,6 +157,58 @@ input::-webkit-inner-spin-button {
 
 // Input groups
 
+.input-group {
+  display: table;
+
+  .form-control {
+    position: relative;
+    width: 100%;
+
+    &:focus {
+      z-index: 2;
+    }
+  }
+
+  .form-control + .btn {
+    margin-left: 0;
+  }
+
+  // For when you want the input group to behave like inline-block.
+  &.inline {
+    display: inline-table;
+  }
+}
+
+.input-group .form-control,
+.input-group-button {
+  display: table-cell;
+}
+
+.input-group-button {
+  width: 1%;
+  vertical-align: middle; // Match the inputs
+}
+
+.input-group .form-control:first-child,
+.input-group-button:first-child .btn {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.input-group-button:first-child .btn {
+  margin-right: -1px;
+}
+
+.input-group .form-control:last-child,
+.input-group-button:last-child .btn {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.input-group-button:last-child .btn {
+  margin-left: -1px;
+}
+
 .form-actions {
   @include clearfix;
 


### PR DESCRIPTION
Used to be here: https://github.com/primer/primer-css/blob/2ff8a486b658a4754cca501edd9c189c3fa0468f/scss/_input-group.scss

Broken on the docs site: http://primercss.io/forms/#input-group

Checked against minified code on GitHub, looks like it hasn't changed. Maybe it's just a misplaced file in the github/github repo, so if you have a better way of fixing no need to merge this PR.